### PR TITLE
feat(footer): link back to the Alphabet Soup ecosystem

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,6 +26,27 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Nav account={<AccountWidget />} />
           <main className="min-w-0 flex-1 px-6 py-8 lg:px-10">
             <div className="mx-auto max-w-6xl">{children}</div>
+            <footer className="mx-auto mt-16 max-w-6xl border-t border-line/60 pt-6 text-xs text-ink/60">
+              <p>
+                Part of the{' '}
+                <a
+                  href="https://www.cybersecurityalphabetsoup.com/"
+                  rel="noopener"
+                  className="hover:text-accent"
+                >
+                  Cybersecurity Alphabet Soup ecosystem
+                </a>
+                .{' '}
+                <a
+                  href="https://www.cybersecurityalphabetsoup.com/about/"
+                  rel="noopener"
+                  className="hover:text-accent"
+                >
+                  Meet the builder
+                </a>
+                .
+              </p>
+            </footer>
           </main>
         </div>
       </body>


### PR DESCRIPTION
Adds a small footer to the app layout tying BIA back to the wider ecosystem:

- **"Part of the Cybersecurity Alphabet Soup ecosystem"** linking to the hub (`https://www.cybersecurityalphabetsoup.com/`)
- **"Meet the builder"** linking to the hub About page (`/about/`)

Styled with the app's own theme tokens (`border-line`, `text-ink`, `hover:text-accent`) and placed at the bottom of the main content column so it matches the existing look. No em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)